### PR TITLE
Pass both source and path to reek examiner

### DIFF
--- a/lib/ruby_lsp/reek/version.rb
+++ b/lib/ruby_lsp/reek/version.rb
@@ -2,6 +2,6 @@
 
 module RubyLsp
   module Reek
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end

--- a/test/ruby_lsp_addon_test.rb
+++ b/test/ruby_lsp_addon_test.rb
@@ -87,7 +87,6 @@ class RubyLspAddonTest < Minitest::Test
     server.global_state.stubs(:typechecker).returns(false) if stub_no_typechecker
 
     if source
-      File.write(uri.to_s, source)
       server.process_message(
         {
           method: "textDocument/didOpen",
@@ -109,7 +108,6 @@ class RubyLspAddonTest < Minitest::Test
     server.load_addons if load_addons
     block.call(server, uri)
   ensure
-    File.unlink(uri.to_s) if File.exist?(uri.to_s)
     if load_addons
       RubyLsp::Addon.addons.each(&:deactivate)
       RubyLsp::Addon.addons.clear


### PR DESCRIPTION
In 0.3.0, this simply passed the path of the file for reek to examine, but this really needed to pass both the current state of the editor and the path. Reek::Examiner doesn't really allow this, so this patches the instance variables set in the initializer.